### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Temporary devops repo
-.devops
+/.devops
 
 # Twine temporary files
 package-lock.json
@@ -103,8 +103,8 @@ instance/
 docs/_build/
 
 # PyBuilder
-.pybuilder/
-target/
+/.pybuilder/
+/target/
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
         args: ["--profile", "black"]
 
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-    rev: v1.6.27.13
+    rev: v1.7.0.14
     hooks:
       - id: actionlint
 


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit